### PR TITLE
adjusted action meta data after rename in kirby

### DIFF
--- a/kirbymessage.cpp
+++ b/kirbymessage.cpp
@@ -16,7 +16,7 @@ KirbyMessage::KirbyMessage(const QString type, const QJsonValue payload, const Q
         _meta["commType"] = "one-way";
 
     if (!_meta["destination"].isString())
-        _meta["destination"] = "POLYPHANT_CLIENT";
+        _meta["destination"] = "CLIENT";
 }
 
 void KirbyMessage::setPayload(const QJsonValue &payload)


### PR DESCRIPTION
i renamed some entities in kirby dev:
POLYPHANT_CLIENT -> CLIENT (angulario, factory test tool)
POLYPHANT_SERVER -> KIRBY
KALAMI -> KALAMI (still)

kirby master still has the old entity names.. if you guys rely on kirby dev, then accept this PR, if you want to work with stable master, then postpone this PR.